### PR TITLE
#4: OpenAPIの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ $ docker-compose up -d doc
 
 ### GitHub Pagesでの確認
 TBD
+
+## Environment / Architecture
+* Kotlin
+* Spring Boot
+* Spring Data JPA
+* オニオンアーキテクチャ
+
+## Infrastructure
+* TBD

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # kotlin-spring-prac
 Kotlin + Spring Bootの練習
+
+* Kotlinサーバーサイドプログラミング実践開発がベースになっている.
+* OpenAPIを導入する.
+* とりあえず一旦モノレポ構成で
+* Terraformも導入出来たら理想
+
+## API Document
+[openapi.yaml](/doc/openapi.yaml)を参照.
+
+### ローカルでの起動方法
+
+```shell
+# 起動
+$ docker-compose up -d doc
+```
+
+起動完了後, http://localhost:8082 にアクセスする.
+
+### GitHub Pagesでの確認
+TBD

--- a/doc/components/shemas/User.yaml
+++ b/doc/components/shemas/User.yaml
@@ -1,0 +1,28 @@
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Product:
+      type: object
+      required:
+        - id
+        - price
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Laptop
+        price:
+          type: integer
+          example: 1200

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  description: >-
+    これはサンプルです
+  version: 0.0.1
+servers:
+  - url: https://example.com
+    description: テストURL
+paths:
+  /items:
+    $ref: "./paths/items.yaml"
+components:
+  schemas:
+    items:
+      $ref: "./components/schemas/User.yaml"

--- a/doc/paths/items.yaml
+++ b/doc/paths/items.yaml
@@ -1,0 +1,21 @@
+/users:
+  get:
+    tags:
+      - tests
+    summary: Get all users.
+    description: 全ユーザを返す
+    parameters: []
+    responses:
+      '200':
+        description: A JSON array of User model
+        content:
+          application/json:
+            schema: 
+              type: array
+              items:
+                $ref: '../components/schemas/User.yaml'
+              example:
+                - id: 1
+                  name: gangan
+                - id: 2
+                  name: gangang 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+
+services:
+  doc:
+    image: swaggerapi/swagger-ui:v4.12.0
+    container_name: api-document
+    ports:
+      - "8002:8080"
+    volumes:
+      - ./doc/openapi.yaml:/openapi.yaml
+    environment:
+      SWAGGER_JSON: /openapi.yaml


### PR DESCRIPTION
### 対応内容
* [x] OpenAPIの追加
* [x] OpenAPIの検証環境を`docker-compose.yml`で用意
* [x] OpenAPIに関する説明をREADME.mdに記載

### 本PRで非対応の内容
* OpenAPIのyamlファイルの中身が正しいかどうか
  => とりあえず動くことの確認のため、中身は適当。
* OpenAPI用yamlファイルに対するリンター
* GitHub Pagesでの表示

### 対応イシュー
close #4 .